### PR TITLE
Added Configuration for Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,5 @@
+version: 1
+update_configs:
+  - package_manager: "java:gradle"
+    directory: "/"
+    update_schedule: "weekly"


### PR DESCRIPTION
Configuration for Dependabot has been created.
The bot will automatically bump the version by sending a Pull Request Weekly. The bot will automatically rebase the changes and resolve the conflicts.

@ShivangiSingh17   Maam you need to Enable the service on the repository by going to the Dependabot Page and clicking on *Install* Button. It requires  write access to the repository so I cannot do this step. Rest of the configuration file has been added by this Pull Request. 
It will Fix #51 
