### PR TITLE
Allow passing an optional color hex, to generate random colors similar to it

### DIFF
--- a/app/src/main/java/in/krharsh17/barview_sample/MainActivity.java
+++ b/app/src/main/java/in/krharsh17/barview_sample/MainActivity.java
@@ -1,5 +1,6 @@
 package in.krharsh17.barview_sample;
 
+import android.graphics.Color;
 import android.os.Bundle;
 import android.widget.Toast;
 
@@ -29,7 +30,7 @@ public class MainActivity extends AppCompatActivity {
         barModels.add(new BarModel(
                 "Samsung",
                 "30.91",
-                getRandomColor(),
+                getRandomColor(new Color().rgb(0,128,0)),
                 0.31f,0,0
         ));
 

--- a/library/src/main/java/in/krharsh17/barview/BarView.java
+++ b/library/src/main/java/in/krharsh17/barview/BarView.java
@@ -17,6 +17,9 @@ import androidx.constraintlayout.widget.ConstraintLayout;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
+
+import static java.lang.Math.min;
 
 /**
  * This is the custom view which is the cumulation of various individual barGroups
@@ -296,6 +299,44 @@ public class BarView extends ScrollView implements Constants {
             color.append(letters[(int) Math.round(Math.floor(Math.random() * 16))]);
         }
         return color.toString();
+    }
+
+    /**
+     * This function approximates the passed in color based on the tolerance value defined in
+     * the method . It first deconstructs the passed in @ColorInt into its components and then
+     * randomly adding or subtracting integers in the range of tolerance and then finally
+     * constructing them all up together and returning a hex literal of the format #XXXXXX
+     *
+     * @param approximateColor is the color user wants the bar to be approximately like
+     * @return
+     */
+    public static String getRandomColor(Integer approximateColor) {
+        Integer tolerance=5;
+        Integer blue=approximateColor&0x000000ff;
+        Integer green=(approximateColor&0x0000ff00)>>8;
+        Integer red=(approximateColor&0x00ff0000)>>16;
+
+        blue = Math.min(Math.max(0,blue+getRandomNumberInRange(-tolerance,tolerance)),255);
+        green = Math.min(Math.max(0,green+getRandomNumberInRange(-tolerance,tolerance)),255);
+        red = Math.min(Math.max(0,red+getRandomNumberInRange(-tolerance,tolerance)),255);
+
+        approximateColor=0xff000000 | (red << 16) | (green << 8) | blue;
+
+        String approximateColorHexLiteral =Integer.toHexString(approximateColor);
+        return ("#"+approximateColorHexLiteral.substring(2));
+    }
+
+    /**
+     * Helper function returns any random integer between the specified bounds
+     * [min..max] both inclusive
+     *
+     * @param min variance the user wants in the approximate color
+     * @param max variance the user wants in the approximate color
+     * @return
+     */
+    private static int getRandomNumberInRange(int min, int max) {
+        Random r = new Random();
+        return r.nextInt((max - min) + 1) + min;
     }
 
     public void setCornerRadius(int radius) {

--- a/library/src/main/java/in/krharsh17/barview/BarView.java
+++ b/library/src/main/java/in/krharsh17/barview/BarView.java
@@ -19,8 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import java.lang.Math;
-
 /**
  * This is the custom view which is the cumulation of various individual barGroups
  * extends from a ScrollView and implementing Constant interface

--- a/library/src/main/java/in/krharsh17/barview/BarView.java
+++ b/library/src/main/java/in/krharsh17/barview/BarView.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import static java.lang.Math.min;
+import java.lang.Math;
 
 /**
  * This is the custom view which is the cumulation of various individual barGroups
@@ -320,9 +320,9 @@ public class BarView extends ScrollView implements Constants {
         green = Math.min(Math.max(0,green+getRandomNumberInRange(-tolerance,tolerance)),255);
         red = Math.min(Math.max(0,red+getRandomNumberInRange(-tolerance,tolerance)),255);
 
-        approximateColor=0xff000000 | (red << 16) | (green << 8) | blue;
+        Integer newApproximateColor=0xff000000 | (red << 16) | (green << 8) | blue;
 
-        String approximateColorHexLiteral =Integer.toHexString(approximateColor);
+        String approximateColorHexLiteral =Integer.toHexString(newApproximateColor);
         return ("#"+approximateColorHexLiteral.substring(2));
     }
 

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -3,6 +3,7 @@
     <declare-styleable name="BarView">
         <attr name="barGroupSpacing" format="dimension" />
         <attr name="barHeight" format="dimension" />
+        <attr name="approximateColor" format="integer" />
         <attr name="labelTextSize" format="dimension"/>
         <attr name="valueTextSize" format="dimension"/>
         <attr name="introAnimationType" format="integer">


### PR DESCRIPTION

## Issue that this pull request solves
Implemented a overload of the current function getRandomColor to get the desired precisely similar color.


Fixes: #2  

## Proposed changes

Brief description of what is fixed or changed
optional param can be passed into the views constructor


## Types of changes

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] Documentation update (Documentation content changed)
-   [ ] Other (please describe): 

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
